### PR TITLE
feat: add API client and helper utilities

### DIFF
--- a/react-app/src/services/apiClient.ts
+++ b/react-app/src/services/apiClient.ts
@@ -1,0 +1,51 @@
+const BASE_URL = import.meta.env.VITE_BASE_URL || ''
+
+type RequestOptions = RequestInit & { baseUrl?: string }
+
+const request = async <T>(
+  path: string,
+  options: RequestOptions = {},
+): Promise<T> => {
+  const url = `${options.baseUrl ?? BASE_URL}${path}`
+  const res = await fetch(url, options)
+  if (!res.ok) {
+    throw new Error(await res.text())
+  }
+  return res.json()
+}
+
+const get = <T>(path: string, options?: RequestOptions) =>
+  request<T>(path, { ...options, method: 'GET' })
+
+const post = <T>(path: string, data: unknown, options?: RequestOptions) =>
+  request<T>(path, {
+    ...options,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options?.headers || {}),
+    },
+    body: JSON.stringify(data),
+  })
+
+const put = <T>(path: string, data: unknown, options?: RequestOptions) =>
+  request<T>(path, {
+    ...options,
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options?.headers || {}),
+    },
+    body: JSON.stringify(data),
+  })
+
+const del = <T>(path: string, options?: RequestOptions) =>
+  request<T>(path, { ...options, method: 'DELETE' })
+
+const postMultipart = <T>(
+  path: string,
+  data: FormData,
+  options?: RequestOptions,
+) => request<T>(path, { ...options, method: 'POST', body: data })
+
+export default { get, post, put, del, postMultipart }

--- a/react-app/src/services/helpers.ts
+++ b/react-app/src/services/helpers.ts
@@ -1,0 +1,21 @@
+const DOMAIN_URL = import.meta.env.VITE_DOMAIN_URL || ''
+
+export const getImageUrl = (path?: string) =>
+  path ? `${DOMAIN_URL}${path}` : ''
+
+export const getTimeAgo = (date: string | number | Date): string => {
+  const past = new Date(date)
+  const diff = Date.now() - past.getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds} giây trước`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} phút trước`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} giờ trước`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days} ngày trước`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months} tháng trước`
+  const years = Math.floor(months / 12)
+  return `${years} năm trước`
+}


### PR DESCRIPTION
## Summary
- add API client built on fetch with wrappers for GET, POST, PUT, DELETE and multipart
- provide helpers for building image URLs and formatting relative time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b290b50b30832987dc8a6303f9bb45