### PR TITLE
Add authentication hook and login routes

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -2,9 +2,15 @@ import { BrowserRouter, Route, Routes, Outlet } from 'react-router-dom'
 import Header from './components/Header'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
+import RouteGuard from './components/RouteGuard'
 import Home from './pages/Home'
 import Profile from './pages/Profile'
 import Flashsale from './pages/Flashsale'
+import Login from './pages/Login'
+import LoginOtp from './pages/LoginOtp'
+import LoginVerifyOtp from './pages/LoginVerifyOtp'
+import Register from './pages/Register'
+import { AuthProvider } from './hooks/useAuth'
 import './styles/App.css'
 
 const Layout = () => (
@@ -17,15 +23,23 @@ const Layout = () => (
 )
 
 const App = () => (
-  <BrowserRouter>
-    <Routes>
-      <Route element={<Layout />}>
-        <Route path="/" element={<Home />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/flashsale" element={<Flashsale />} />
-      </Route>
-    </Routes>
-  </BrowserRouter>
+  <AuthProvider>
+    <BrowserRouter>
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/flashsale" element={<Flashsale />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/login-otp" element={<LoginOtp />} />
+          <Route path="/login-verify-otp" element={<LoginVerifyOtp />} />
+          <Route path="/register" element={<Register />} />
+          <Route element={<RouteGuard />}>
+            <Route path="/profile" element={<Profile />} />
+          </Route>
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  </AuthProvider>
 )
 
 export default App

--- a/react-app/src/components/RouteGuard.tsx
+++ b/react-app/src/components/RouteGuard.tsx
@@ -1,0 +1,9 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+const RouteGuard = () => {
+  const { token } = useAuth()
+  return token ? <Outlet /> : <Navigate to="/login" replace />
+}
+
+export default RouteGuard

--- a/react-app/src/hooks/useAuth.ts
+++ b/react-app/src/hooks/useAuth.ts
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+  createElement,
+} from 'react'
+
+type AuthContextType = {
+  token: string | null
+  login: (token: string) => void
+  logout: () => void
+}
+
+const TOKEN_KEY = 'jwt_token'
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(() =>
+    localStorage.getItem(TOKEN_KEY),
+  )
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem(TOKEN_KEY, token)
+    } else {
+      localStorage.removeItem(TOKEN_KEY)
+    }
+  }, [token])
+
+  const login = (newToken: string) => setToken(newToken)
+  const logout = () => setToken(null)
+
+  return createElement(
+    AuthContext.Provider,
+    { value: { token, login, logout } },
+    children,
+  )
+}
+
+export const useAuth = () => {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return context
+}

--- a/react-app/src/pages/Login.tsx
+++ b/react-app/src/pages/Login.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { useNavigate, Link } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+import { useAuth } from '../hooks/useAuth'
+
+const Login = () => {
+  const [phone, setPhone] = useState('')
+  const [password, setPassword] = useState('')
+  const navigate = useNavigate()
+  const { login } = useAuth()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { token } = await apiClient.post<{ token: string }>('/login', {
+      phone,
+      password,
+    })
+    login(token)
+    navigate('/profile')
+  }
+
+  return (
+    <div>
+      <h1>Đăng nhập</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="tel"
+          placeholder="Số điện thoại"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Mật khẩu"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Đăng nhập</button>
+      </form>
+      <Link to="/login-otp">Đăng nhập bằng OTP</Link>
+    </div>
+  )
+}
+
+export default Login

--- a/react-app/src/pages/LoginOtp.tsx
+++ b/react-app/src/pages/LoginOtp.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+
+const LoginOtp = () => {
+  const [phone, setPhone] = useState('')
+  const navigate = useNavigate()
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await apiClient.post('/login-otp', { phone })
+    navigate('/login-verify-otp', { state: { phone } })
+  }
+
+  return (
+    <div>
+      <h1>Gửi OTP</h1>
+      <form onSubmit={handleSend}>
+        <input
+          type="tel"
+          placeholder="Số điện thoại"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+        />
+        <button type="submit">Gửi OTP</button>
+      </form>
+    </div>
+  )
+}
+
+export default LoginOtp

--- a/react-app/src/pages/LoginVerifyOtp.tsx
+++ b/react-app/src/pages/LoginVerifyOtp.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+import { useAuth } from '../hooks/useAuth'
+
+const LoginVerifyOtp = () => {
+  const [otp, setOtp] = useState('')
+  const navigate = useNavigate()
+  const { state } = useLocation() as { state: { phone: string } }
+  const { login } = useAuth()
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { token } = await apiClient.post<{ token: string }>(
+      '/login-verify-otp',
+      {
+        phone: state?.phone,
+        otp,
+      },
+    )
+    login(token)
+    navigate('/profile')
+  }
+
+  return (
+    <div>
+      <h1>Xác nhận OTP</h1>
+      <form onSubmit={handleVerify}>
+        <input
+          type="text"
+          placeholder="Mã OTP"
+          value={otp}
+          onChange={(e) => setOtp(e.target.value)}
+        />
+        <button type="submit">Xác nhận</button>
+      </form>
+    </div>
+  )
+}
+
+export default LoginVerifyOtp

--- a/react-app/src/pages/Register.tsx
+++ b/react-app/src/pages/Register.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+
+const Register = () => {
+  const [phone, setPhone] = useState('')
+  const [password, setPassword] = useState('')
+  const navigate = useNavigate()
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await apiClient.post('/register', { phone, password })
+    navigate('/login')
+  }
+
+  return (
+    <div>
+      <h1>Đăng ký</h1>
+      <form onSubmit={handleRegister}>
+        <input
+          type="tel"
+          placeholder="Số điện thoại"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Mật khẩu"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Đăng ký</button>
+      </form>
+    </div>
+  )
+}
+
+export default Register


### PR DESCRIPTION
## Summary
- manage JWT tokens via useAuth hook stored in memory and localStorage
- add login, OTP, verify-OTP, and register pages
- protect private pages with RouteGuard and wire routes in App

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2996e3e4883298a94e1b47ff7fec7