### PR TITLE
feat: implement home feed with infinite scroll

### DIFF
--- a/react-app/src/components/PostGeneral.tsx
+++ b/react-app/src/components/PostGeneral.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react'
+import { Post } from '../types'
+import { getImageUrl, getTimeAgo } from '../services/helpers'
+
+const PostGeneral = ({ post }: { post: Post }) => {
+  const [expanded, setExpanded] = useState(false)
+  const [showToggle, setShowToggle] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = contentRef.current
+    if (el && el.scrollHeight > el.offsetHeight) {
+      setShowToggle(true)
+    }
+  }, [])
+
+  const profileImage = post.user.profile_image.startsWith('http')
+    ? post.user.profile_image
+    : getImageUrl(post.user.profile_image)
+
+  const images = post.images || []
+
+  return (
+    <div className="post">
+      <div className="user">
+        <img src={profileImage} alt="User Profile" />
+        <div className="name">{post.user.name}</div>
+      </div>
+      <div className="meta">
+        <i>🗺️</i> <span>Tiêu đề: {post.tour_name}</span>
+      </div>
+      {images.map((img, idx) => {
+        const src = img.startsWith('http') ? img : getImageUrl(img)
+        return <img key={idx} className="image" src={src} alt="Tour Image" />
+      })}
+      <div className="content-wrapper">
+        <div
+          className="content"
+          id={`content-${post.id}`}
+          ref={contentRef}
+          style={{ display: expanded ? 'block' : '-webkit-box' }}
+          dangerouslySetInnerHTML={{ __html: post.content || '' }}
+        />
+        {showToggle && (
+          <a
+            href="#"
+            className="toggle-content"
+            onClick={(e) => {
+              e.preventDefault()
+              setExpanded((p) => !p)
+            }}
+            id={`toggle-${post.id}`}
+          >
+            {expanded ? 'Show Less' : 'Show More'}
+          </a>
+        )}
+      </div>
+      <div className="time">Đăng: {getTimeAgo(post.created_at)}</div>
+      <div className="likes">{post.likes} likes</div>
+    </div>
+  )
+}
+
+export default PostGeneral

--- a/react-app/src/components/PostReview.tsx
+++ b/react-app/src/components/PostReview.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react'
+import { Post } from '../types'
+import { getImageUrl, getTimeAgo } from '../services/helpers'
+
+const PostReview = ({ post }: { post: Post }) => {
+  const [expanded, setExpanded] = useState(false)
+  const [showToggle, setShowToggle] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = contentRef.current
+    if (el && el.scrollHeight > el.offsetHeight) {
+      setShowToggle(true)
+    }
+  }, [])
+
+  const profileImage = post.user.profile_image.startsWith('http')
+    ? post.user.profile_image
+    : getImageUrl(post.user.profile_image)
+
+  const images = post.images || []
+  const formattedDate = post.start_date
+    ? new Date(post.start_date).toLocaleDateString('vi-VN')
+    : ''
+
+  return (
+    <div className="post">
+      <div className="user">
+        <img src={profileImage} alt="User Profile" />
+        <div className="name">{post.user.name}</div>
+      </div>
+      {post.tour_name && (
+        <div className="meta">
+          <i>🗺️</i> <span>Tên tour: {post.tour_name}</span>
+          {post.start_date && (
+            <>
+              {' '}
+              <span>|</span> <span>Ngày khởi hành: {formattedDate}</span>
+            </>
+          )}
+        </div>
+      )}
+      {post.guide_name && (
+        <div className="meta">
+          <i>🧑‍🏫</i> <span>Hướng dẫn: {post.guide_name}</span>
+        </div>
+      )}
+      {images.map((img, idx) => {
+        const src = img.startsWith('http') ? img : getImageUrl(img)
+        return <img key={idx} className="image" src={src} alt="Tour Image" />
+      })}
+      <div className="content-wrapper">
+        <div
+          className="content"
+          id={`content-${post.id}`}
+          ref={contentRef}
+          style={{ display: expanded ? 'block' : '-webkit-box' }}
+          dangerouslySetInnerHTML={{ __html: post.raw_content || '' }}
+        />
+        {showToggle && (
+          <a
+            href="#"
+            className="toggle-content"
+            onClick={(e) => {
+              e.preventDefault()
+              setExpanded((p) => !p)
+            }}
+            id={`toggle-${post.id}`}
+          >
+            {expanded ? 'Show Less' : 'Show More'}
+          </a>
+        )}
+      </div>
+      <div className="time">Đăng: {getTimeAgo(post.created_at)}</div>
+      <div className="likes">{post.likes} likes</div>
+    </div>
+  )
+}
+
+export default PostReview

--- a/react-app/src/components/PostReviewSale.tsx
+++ b/react-app/src/components/PostReviewSale.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react'
+import { Post } from '../types'
+import { getImageUrl, getTimeAgo } from '../services/helpers'
+
+const displayRatingStars = (rating: number) => {
+  const max = 10
+  return (
+    <>
+      {Array.from({ length: max }, (_, i) => (
+        <span key={i} style={{ color: i < rating ? 'gold' : '#ccc' }}>
+          {i < rating ? '★' : '☆'}
+        </span>
+      ))}
+    </>
+  )
+}
+
+const PostReviewSale = ({ post }: { post: Post }) => {
+  const [expanded, setExpanded] = useState(false)
+  const [showToggle, setShowToggle] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = contentRef.current
+    if (el && el.scrollHeight > el.offsetHeight) {
+      setShowToggle(true)
+    }
+  }, [])
+
+  const profileImage = post.user.profile_image.startsWith('http')
+    ? post.user.profile_image
+    : getImageUrl(post.user.profile_image)
+
+  const images = post.images || []
+
+  type Decoded = { rating?: number; review?: string; booking_id?: string }
+  let decoded: Decoded = {}
+  try {
+    decoded = post.raw_content ? JSON.parse(post.raw_content) : {}
+  } catch {
+    decoded = {}
+  }
+
+  const rating = typeof decoded.rating === 'number' ? decoded.rating : 10
+  const review = decoded.review || ''
+  const bookingId = decoded.booking_id
+  const ratingDisplay = displayRatingStars(rating)
+  const createdDate = post.created_at
+    ? new Date(post.created_at).toLocaleDateString('vi-VN')
+    : ''
+
+  return (
+    <div className="post">
+      <div className="user">
+        <img src={profileImage} alt="User Profile" />
+        <div className="name">{post.user.name}</div>
+      </div>
+      <div className="meta">
+        <i>🆔</i> <span>Mã booking: {bookingId}</span>
+      </div>
+      {post.tour_name && (
+        <div className="meta">
+          <i>🗺️</i> <span>Tên tour: {post.tour_name}</span> <span>|</span>{' '}
+          <span>Ngày đánh giá: {createdDate}</span>
+        </div>
+      )}
+      {post.guide_name && (
+        <>
+          <div className="meta">
+            <i>🧑‍🏫</i> <span>Nhân viên Sale: {post.guide_name}</span>
+          </div>
+          <div className="meta">
+            <i>🌟</i> <span>Rating: {ratingDisplay}</span> | ({rating}/10)
+          </div>
+          <div className="content-wrapper">
+            <div
+              className="content"
+              id={`content-${post.id}`}
+              ref={contentRef}
+              style={{ display: expanded ? 'block' : '-webkit-box' }}
+            >
+              <i>📝</i> Nội dung đánh giá: {review}
+            </div>
+            {showToggle && (
+              <a
+                href="#"
+                className="toggle-content"
+                onClick={(e) => {
+                  e.preventDefault()
+                  setExpanded((p) => !p)
+                }}
+                id={`toggle-${post.id}`}
+              >
+                {expanded ? 'Show Less' : 'Show More'}
+              </a>
+            )}
+          </div>
+        </>
+      )}
+      {images.map((img, idx) => {
+        const src = img.startsWith('http') ? img : getImageUrl(img)
+        return <img key={idx} className="image" src={src} alt="Tour Image" />
+      })}
+      <div className="time">Đăng: {getTimeAgo(post.created_at)}</div>
+      <div className="likes">{post.likes} likes</div>
+    </div>
+  )
+}
+
+export default PostReviewSale

--- a/react-app/src/pages/Home.tsx
+++ b/react-app/src/pages/Home.tsx
@@ -1,3 +1,123 @@
-const Home = () => <div>Home Page</div>
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+import { Post, Statistics } from '../types'
+import PostReview from '../components/PostReview'
+import PostGeneral from '../components/PostGeneral'
+import PostReviewSale from '../components/PostReviewSale'
+
+const PAGE_SIZE = 20
+
+const Home = () => {
+  const [stats, setStats] = useState<Statistics>({})
+  const [posts, setPosts] = useState<Post[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [searchParams] = useSearchParams()
+  const type = searchParams.get('type') ?? 'all'
+  const loader = useRef<HTMLDivElement>(null)
+
+  const fetchInitial = useCallback(async () => {
+    setLoading(true)
+    try {
+      const statsRes = await apiClient.get<{ data: Statistics }>('/statistics')
+      setStats(statsRes.data || {})
+      const postsRes = await apiClient.get<{
+        data: { posts: Post[]; cursor?: string }
+      }>(
+        `/posts?page_size=${PAGE_SIZE}&page=1&type=${
+          type === 'all' ? '' : type
+        }`,
+      )
+      setPosts(postsRes.data.posts || [])
+      setCursor(postsRes.data.cursor || null)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [type])
+
+  useEffect(() => {
+    fetchInitial()
+  }, [fetchInitial])
+
+  const loadMore = useCallback(async () => {
+    if (!cursor || loading) return
+    setLoading(true)
+    try {
+      const res = await apiClient.get<{
+        data: { posts: Post[]; cursor?: string }
+      }>(`/posts?cursor=${cursor}&type=${type === 'all' ? '' : type}`)
+      setPosts((prev) => [...prev, ...(res.data.posts || [])])
+      setCursor(res.data.cursor || null)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [cursor, type, loading])
+
+  useEffect(() => {
+    const el = loader.current
+    if (!el) return
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        loadMore()
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [loadMore])
+
+  const filters = [
+    { value: 'all', label: 'Tất cả' },
+    { value: 'review', label: 'Đánh giá tour' },
+    { value: 'review_sale', label: 'Đánh giá tư vấn' },
+    { value: 'general', label: 'Giới thiệu tour' },
+  ]
+
+  return (
+    <>
+      <div className="statistics">
+        <div className="stat">
+          <div className="value">{stats.users ?? 0}+</div>
+          <div className="label">Thành viên</div>
+        </div>
+        <div className="stat">
+          <div className="value">{stats.posts ?? 0}+</div>
+          <div className="label">Bài viết</div>
+        </div>
+      </div>
+      <div className="filter-container">
+        {filters.map((f) => (
+          <Link
+            key={f.value}
+            to={`/?type=${f.value}`}
+            className={type === f.value ? 'active' : ''}
+          >
+            {f.label}
+          </Link>
+        ))}
+      </div>
+      <div className="feed" id="feed">
+        {posts.map((post) => {
+          switch (post.type) {
+            case 'review':
+              return <PostReview key={post.id} post={post} />
+            case 'general':
+              return <PostGeneral key={post.id} post={post} />
+            case 'review_sale':
+              return <PostReviewSale key={post.id} post={post} />
+            default:
+              return null
+          }
+        })}
+      </div>
+      {cursor && <div ref={loader} />}
+      {loading && <p style={{ textAlign: 'center' }}>Loading...</p>}
+    </>
+  )
+}
 
 export default Home

--- a/react-app/src/types.ts
+++ b/react-app/src/types.ts
@@ -1,0 +1,23 @@
+export interface User {
+  name: string
+  profile_image: string
+}
+
+export interface Post {
+  id: number
+  type: 'review' | 'general' | 'review_sale'
+  user: User
+  tour_name?: string | null
+  start_date?: string | null
+  guide_name?: string | null
+  images?: string[]
+  raw_content?: string
+  content?: string
+  likes: number
+  created_at: string
+}
+
+export interface Statistics {
+  users?: number
+  posts?: number
+}


### PR DESCRIPTION
## Summary
- add type-safe post models and renderers for review, general, and sale review posts
- build home feed that fetches statistics and posts with infinite scroll and query-string type filters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2a1dcdecc8329bc1c6907006ec928