### PR TITLE
feat: add review pages and otp verification

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -10,6 +10,9 @@ import Login from './pages/Login'
 import LoginOtp from './pages/LoginOtp'
 import LoginVerifyOtp from './pages/LoginVerifyOtp'
 import Register from './pages/Register'
+import Review from './pages/Review'
+import ReviewByQr from './pages/ReviewByQr'
+import VerifyOtp from './pages/VerifyOtp'
 import { AuthProvider } from './hooks/useAuth'
 import './styles/App.css'
 
@@ -33,6 +36,9 @@ const App = () => (
           <Route path="/login-otp" element={<LoginOtp />} />
           <Route path="/login-verify-otp" element={<LoginVerifyOtp />} />
           <Route path="/register" element={<Register />} />
+          <Route path="/review" element={<Review />} />
+          <Route path="/reviewbyqr" element={<ReviewByQr />} />
+          <Route path="/verify-otp" element={<VerifyOtp />} />
           <Route element={<RouteGuard />}>
             <Route path="/profile" element={<Profile />} />
           </Route>

--- a/react-app/src/components/ReviewForm.tsx
+++ b/react-app/src/components/ReviewForm.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+
+type Props = {
+  tourId?: string
+}
+
+const ReviewForm = ({ tourId }: Props) => {
+  const [content, setContent] = useState('')
+  const [files, setFiles] = useState<FileList | null>(null)
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const formData = new FormData()
+    formData.append('content', content)
+    if (tourId) {
+      formData.append('tour_id', tourId)
+    }
+    if (files) {
+      Array.from(files).forEach((file) => {
+        formData.append('images', file)
+      })
+    }
+    try {
+      await apiClient.postMultipart('/reviews', formData)
+      navigate('/verify-otp', { state: { tourId } })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <textarea
+        placeholder="Nội dung đánh giá"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <input type="file" multiple onChange={(e) => setFiles(e.target.files)} />
+      <button type="submit">Gửi đánh giá</button>
+    </form>
+  )
+}
+
+export default ReviewForm

--- a/react-app/src/pages/Review.tsx
+++ b/react-app/src/pages/Review.tsx
@@ -1,0 +1,10 @@
+import ReviewForm from '../components/ReviewForm'
+
+const Review = () => (
+  <div>
+    <h1>Đánh giá tự do</h1>
+    <ReviewForm />
+  </div>
+)
+
+export default Review

--- a/react-app/src/pages/ReviewByQr.tsx
+++ b/react-app/src/pages/ReviewByQr.tsx
@@ -1,0 +1,16 @@
+import { useSearchParams } from 'react-router-dom'
+import ReviewForm from '../components/ReviewForm'
+
+const ReviewByQr = () => {
+  const [searchParams] = useSearchParams()
+  const tourId = searchParams.get('tour_id') ?? undefined
+
+  return (
+    <div>
+      <h1>Đánh giá tour</h1>
+      <ReviewForm tourId={tourId} />
+    </div>
+  )
+}
+
+export default ReviewByQr

--- a/react-app/src/pages/VerifyOtp.tsx
+++ b/react-app/src/pages/VerifyOtp.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+
+type State = {
+  tourId?: string
+}
+
+const VerifyOtp = () => {
+  const [otp, setOtp] = useState('')
+  const navigate = useNavigate()
+  const { state } = useLocation() as { state: State }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await apiClient.post('/verify-otp', { otp, tour_id: state?.tourId })
+      navigate('/')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Xác nhận OTP</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Mã OTP"
+          value={otp}
+          onChange={(e) => setOtp(e.target.value)}
+        />
+        <button type="submit">Xác nhận</button>
+      </form>
+    </div>
+  )
+}
+
+export default VerifyOtp


### PR DESCRIPTION
## Summary
- add routes for review, review-by-qr, and OTP verification
- implement review form with FormData for multiple images
- allow QR flow to pre-fill tour ID and redirect to OTP check

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TS1484 must import types using type-only imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ffa6b7608329b28336106f3a3bf0