### PR TITLE
feat: add QR generation and redirect utilities

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -14,6 +14,8 @@ import LoginVerifyOtp from './pages/LoginVerifyOtp'
 import Register from './pages/Register'
 import Review from './pages/Review'
 import ReviewByQr from './pages/ReviewByQr'
+import GenQr from './pages/GenQr'
+import RedirectApp from './pages/RedirectApp'
 import VerifyOtp from './pages/VerifyOtp'
 import { AuthProvider } from './hooks/useAuth'
 import './styles/App.css'
@@ -40,6 +42,9 @@ const App = () => (
           <Route path="/register" element={<Register />} />
           <Route path="/review" element={<Review />} />
           <Route path="/reviewbyqr" element={<ReviewByQr />} />
+          <Route path="/genqr" element={<GenQr />} />
+          <Route path="/genqr-vngroup" element={<GenQr variant="vngroup" />} />
+          <Route path="/redirectapp" element={<RedirectApp />} />
           <Route path="/verify-otp" element={<VerifyOtp />} />
           <Route element={<RouteGuard />}>
             <Route path="/profile" element={<Profile />} />

--- a/react-app/src/pages/GenQr.tsx
+++ b/react-app/src/pages/GenQr.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import '../styles/genqr.css'
+
+interface GenQrProps {
+  variant?: 'vngroup'
+}
+
+const GenQr = ({ variant }: GenQrProps) => {
+  const location = useLocation()
+  const isVnGroup = variant === 'vngroup' || location.pathname.includes('genqr-vngroup')
+  const [tourName, setTourName] = useState('')
+  const [startDate, setStartDate] = useState('')
+  const [endDate, setEndDate] = useState('')
+  const [guideName, setGuideName] = useState('')
+  const [qrUrl, setQrUrl] = useState('')
+
+  const primaryColor = isVnGroup ? '#007BFF' : '#660066'
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const baseUrl = `${window.location.origin}/${isVnGroup ? 'reviewbyqr-vngroup' : 'reviewbyqr'}`
+    const params = new URLSearchParams({
+      tour_name: tourName,
+      start_date: startDate,
+      end_date: endDate,
+      guide_name: guideName,
+    })
+    setQrUrl(`${baseUrl}?${params.toString()}`)
+  }
+
+  return (
+    <div className="genqr-container">
+      <h1 style={{ color: primaryColor }}>Generate QR Code</h1>
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="tour_name">Tour Name</label>
+          <input
+            type="text"
+            id="tour_name"
+            name="tour_name"
+            value={tourName}
+            onChange={(e) => setTourName(e.target.value)}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="start_date">Start Date</label>
+          <input
+            type="date"
+            id="start_date"
+            name="start_date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="end_date">End Date</label>
+          <input
+            type="date"
+            id="end_date"
+            name="end_date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="guide_name">Guide Name</label>
+          <input
+            type="text"
+            id="guide_name"
+            name="guide_name"
+            value={guideName}
+            onChange={(e) => setGuideName(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="submit-button"
+          style={{ backgroundColor: primaryColor }}
+        >
+          Generate QR Code
+        </button>
+      </form>
+      {qrUrl && (
+        <div className="qr-code-section">
+          <h2>QR Code</h2>
+          <p>Scan this QR code to review the tour:</p>
+          <img
+            src={`https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(qrUrl)}`}
+            alt="QR Code"
+          />
+          <p>
+            <strong>URL:</strong>{' '}
+            <a
+              href={qrUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: primaryColor }}
+            >
+              {qrUrl}
+            </a>
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GenQr

--- a/react-app/src/pages/RedirectApp.tsx
+++ b/react-app/src/pages/RedirectApp.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+const RedirectApp = () => {
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token') || ''
+  const deepLink = `tugo://reset-password?token=${token}`
+  const isZalo = /zalo/i.test(navigator.userAgent)
+
+  useEffect(() => {
+    if (!isZalo) {
+      window.location.href = deepLink
+    }
+  }, [deepLink, isZalo])
+
+  return (
+    <div style={{ textAlign: 'center', padding: '40px', color: '#333' }}>
+      <h2>🔄 Đang mở ứng dụng Tugo...</h2>
+      {isZalo && (
+        <p>Trình duyệt Zalo không hỗ trợ mở trực tiếp. Vui lòng mở bằng trình duyệt khác.</p>
+      )}
+      <p>Nếu bạn thấy thông báo này quá lâu, hãy nhấn nút bên dưới để mở thủ công:</p>
+      <a
+        href={deepLink}
+        style={{
+          display: 'inline-block',
+          marginTop: 20,
+          padding: '12px 24px',
+          backgroundColor: '#1e88e5',
+          color: '#fff',
+          textDecoration: 'none',
+          borderRadius: 6,
+        }}
+      >
+        Mở ứng dụng Tugo
+      </a>
+    </div>
+  )
+}
+
+export default RedirectApp

--- a/react-app/src/styles/genqr.css
+++ b/react-app/src/styles/genqr.css
@@ -1,0 +1,55 @@
+.genqr-container {
+  max-width: 400px;
+  margin: 20px auto;
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.genqr-container h1 {
+  margin-bottom: 20px;
+}
+
+.form-group {
+  margin-bottom: 15px;
+  text-align: left;
+}
+
+.form-group label {
+  display: block;
+  font-weight: bold;
+  margin-bottom: 5px;
+  color: #555;
+}
+
+.form-group input {
+  width: calc(100% - 20px);
+  padding: 10px;
+  margin-left: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  font-size: 14px;
+}
+
+.submit-button {
+  width: 100%;
+  padding: 10px;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.qr-code-section {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.qr-code-section img {
+  margin: 10px 0;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+}


### PR DESCRIPTION
## Summary
- add GenQr page with URL-based QR code generation and VNGroup variant
- introduce RedirectApp page with Zalo browser detection and deep link redirect
- wire new routes for QR and redirect utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3010e8ee4832984c8410805b6dfc1