### PR TITLE
feat: add flash sale pages

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -8,6 +8,7 @@ import Profile from './pages/Profile'
 import EditProfile from './pages/EditProfile'
 import Voucher from './pages/Voucher'
 import Flashsale from './pages/Flashsale'
+import FlashSaleDetail from './pages/FlashSaleDetail'
 import Login from './pages/Login'
 import LoginOtp from './pages/LoginOtp'
 import LoginVerifyOtp from './pages/LoginVerifyOtp'
@@ -36,6 +37,7 @@ const App = () => (
         <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
           <Route path="/flashsale" element={<Flashsale />} />
+          <Route path="/flashsale/:id" element={<FlashSaleDetail />} />
           <Route path="/login" element={<Login />} />
           <Route path="/login-otp" element={<LoginOtp />} />
           <Route path="/login-verify-otp" element={<LoginVerifyOtp />} />

--- a/react-app/src/components/FlashSaleMenu.tsx
+++ b/react-app/src/components/FlashSaleMenu.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react'
+
+interface MenuItem {
+  id: string
+  name: string
+}
+
+const FlashSaleMenu: FC<{ items: MenuItem[] }> = ({ items }) => {
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+
+  return (
+    <div className="flashsale-menu">
+      {items.map((item) => (
+        <button key={item.id} onClick={() => scrollTo(item.id)}>
+          {item.name}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default FlashSaleMenu

--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+import '../styles/flashsale.css'
+import { FlashSaleDeparture } from '../types'
+
+type DetailResponse = {
+  data: {
+    tour: { output_json: { data: { name: string } } }
+    prices: FlashSaleDeparture[]
+  }
+}
+
+const formatCurrency = (val: number) =>
+  new Intl.NumberFormat('vi-VN').format(val) + '₫'
+
+const FlashSaleDetail = () => {
+  const { id } = useParams()
+  const [tourName, setTourName] = useState('')
+  const [prices, setPrices] = useState<FlashSaleDeparture[]>([])
+  const [selected, setSelected] = useState<string>('')
+  const [quantity, setQuantity] = useState(1)
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return
+      const res = await apiClient.get<DetailResponse>(
+        `/flashsale/tour-detail?tour_id=${id}&force_refresh=true`,
+      )
+      setTourName(res.data.tour.output_json.data.name)
+      setPrices(res.data.prices || [])
+      if (res.data.prices?.length) {
+        setSelected(res.data.prices[0].departure_date)
+      }
+    }
+    fetchData()
+  }, [id])
+
+  const selectedPrice =
+    prices.find((p) => p.departure_date === selected)?.price || 0
+  const total = selectedPrice * quantity
+
+  const book = async () => {
+    if (!id || !selected || !name || !phone) {
+      alert('Vui lòng nhập đầy đủ thông tin')
+      return
+    }
+    setLoading(true)
+    try {
+      await apiClient.post('/flashsale/booking', {
+        tour_id: id,
+        departure_date: selected,
+        name,
+        phone,
+        quantity,
+        price: selectedPrice,
+      })
+      alert('Đặt tour thành công!')
+    } catch {
+      alert('Không thể đặt tour')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="flashsale-page">
+      <h1>{tourName}</h1>
+      <div className="departures">
+        {prices
+          .filter((p) => p.available_slots > 0)
+          .map((p) => (
+            <button
+              key={p.departure_date}
+              className={
+                'departure' + (selected === p.departure_date ? ' selected' : '')
+              }
+              onClick={() => setSelected(p.departure_date)}
+            >
+              {new Date(p.departure_date).toLocaleDateString('vi-VN')}
+            </button>
+          ))}
+      </div>
+      <div className="quantity">
+        <button onClick={() => setQuantity((q) => Math.max(1, q - 1))}>
+          -
+        </button>
+        <input
+          type="number"
+          value={quantity}
+          min={1}
+          onChange={(e) => setQuantity(parseInt(e.target.value) || 1)}
+        />
+        <button onClick={() => setQuantity((q) => q + 1)}>+</button>
+      </div>
+      <div>
+        <input
+          placeholder="Họ và tên"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+      <div>
+        <input
+          placeholder="Số điện thoại"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+        />
+      </div>
+      <p>Tổng cộng: {formatCurrency(total)}</p>
+      <button onClick={book} disabled={loading}>
+        {loading ? 'Đang xử lý...' : 'Đặt ngay'}
+      </button>
+    </div>
+  )
+}
+
+export default FlashSaleDetail

--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -1,3 +1,116 @@
-const Flashsale = () => <div>Flashsale Page</div>
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import apiClient from '../services/apiClient'
+import FlashSaleMenu from '../components/FlashSaleMenu'
+import '../styles/flashsale.css'
+import { FlashSaleCollection } from '../types'
+
+type HomeResponse = {
+  data: {
+    campaign_info: { end_time: string }
+    collections: FlashSaleCollection[]
+  }
+}
+
+const idMap: Record<string, string> = {
+  'Tour Đài Loan': 'tour_dai_loan',
+  'Tour Hàn Quốc': 'tour_han_quoc',
+  'Tour Nhật Bản': 'tour_nhat_ban',
+  'Tour Châu Á': 'tour_chau_a',
+  'Tour Châu Úc': 'tour_uc',
+  'Tour Trung Quốc': 'tour_trung_quoc',
+  'Tour Châu Âu': 'tour_chau_au',
+}
+
+const getIdCodeByName = (name: string) =>
+  idMap[name] || name.toLowerCase().replace(/\s+/g, '_')
+
+const formatDate = (iso?: string) => {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return `${d.getDate().toString().padStart(2, '0')}/${(d.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}`
+}
+
+const formatPrice = (price: number) => `${(price / 1_000_000).toFixed(1)}tr`
+
+const Flashsale = () => {
+  const [collections, setCollections] = useState<FlashSaleCollection[]>([])
+  const [countdown, setCountdown] = useState('')
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await apiClient.get<HomeResponse>(
+        '/flashsale/homepage?campaign_id=3',
+      )
+      setCollections(res.data.collections || [])
+      const end = res.data.campaign_info?.end_time
+      if (end) {
+        const update = () => {
+          const diff = new Date(end).getTime() - Date.now()
+          if (diff <= 0) {
+            setCountdown('Flash Sale đã kết thúc')
+          } else {
+            const days = Math.floor(diff / 86400000)
+            const hours = Math.floor((diff % 86400000) / 3600000)
+            const minutes = Math.floor((diff % 3600000) / 60000)
+            const seconds = Math.floor((diff % 60000) / 1000)
+            setCountdown(
+              `Còn ${days} ngày ${hours.toString().padStart(2, '0')}:${minutes
+                .toString()
+                .padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`,
+            )
+          }
+        }
+        update()
+        const id = setInterval(update, 1000)
+        return () => clearInterval(id)
+      }
+    }
+    fetchData()
+  }, [])
+
+  const menuItems = collections.map((c) => ({
+    id: getIdCodeByName(c.collection_name),
+    name: c.collection_name,
+  }))
+
+  return (
+    <div className="flashsale-page">
+      <h1>Flash Sale</h1>
+      {countdown && <p className="countdown">{countdown}</p>}
+      <FlashSaleMenu items={menuItems} />
+      {collections.map((col) => (
+        <section
+          id={getIdCodeByName(col.collection_name)}
+          key={col.collection_name}
+        >
+          <h2>{col.collection_name}</h2>
+          <div className="tours">
+            {col.tours.map((tour) => (
+              <div key={tour.tour_id} className="tour-card">
+                <img src={tour.tour_image} alt={tour.tour_name} />
+                <h3>{tour.tour_name}</h3>
+                <div className="departures">
+                  {tour.departures.slice(0, 4).map((dep) => (
+                    <div
+                      key={dep.date || dep.departure_date}
+                      className="departure"
+                    >
+                      <span>{formatDate(dep.date || dep.departure_date)}</span>
+                      <span> - {formatPrice(dep.price)}</span>
+                    </div>
+                  ))}
+                </div>
+                <Link to={`/flashsale/${tour.tour_id}`}>Xem chi tiết</Link>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
 
 export default Flashsale

--- a/react-app/src/styles/flashsale.css
+++ b/react-app/src/styles/flashsale.css
@@ -1,0 +1,39 @@
+.flashsale-menu {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.flashsale-menu button {
+  padding: 6px 12px;
+  border: none;
+  background: #660066;
+  color: #fff;
+  border-radius: 9999px;
+  cursor: pointer;
+}
+
+.flashsale-menu button:hover {
+  opacity: 0.9;
+}
+
+.flashsale-page .tour-card {
+  border: 1px solid #e5e7eb;
+  padding: 8px;
+  margin-top: 12px;
+}
+
+.departures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.departure {
+  background: #f3f4f6;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+}

--- a/react-app/src/types.ts
+++ b/react-app/src/types.ts
@@ -45,3 +45,23 @@ export interface ProfileData {
   vouchers: Voucher[]
   reviews: Review[]
 }
+
+export interface FlashSaleDeparture {
+  date?: string
+  departure_date?: string
+  price: number
+  available_slots?: number
+}
+
+export interface FlashSaleTour {
+  tour_id: number
+  tour_name: string
+  tour_image: string
+  departures: FlashSaleDeparture[]
+}
+
+export interface FlashSaleCollection {
+  collection_name: string
+  collection_image: string
+  tours: FlashSaleTour[]
+}


### PR DESCRIPTION
## Summary
- build flash sale menu component
- add flash sale listing with countdown and collections
- add flash sale detail page with booking

## Testing
- `npm run lint` *(fails: prettier issues in existing files)*
- `npx eslint src/components/FlashSaleMenu.tsx src/pages/FlashSaleDetail.tsx src/pages/Flashsale.tsx src/types.ts`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b30224e47c8329868057f55d1cd41b