### PR TITLE
chore: use type-only imports

### DIFF
--- a/react-app/src/components/FlashSaleMenu.tsx
+++ b/react-app/src/components/FlashSaleMenu.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import type { FC } from 'react'
 import styles from '../styles/flashsale-menu.module.css'
 
 interface MenuItem {

--- a/react-app/src/components/PostGeneral.tsx
+++ b/react-app/src/components/PostGeneral.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Post } from '../types'
+import type { Post } from '../types'
 import { getImageUrl, getTimeAgo } from '../services/helpers'
 
 const PostGeneral = ({ post }: { post: Post }) => {

--- a/react-app/src/components/PostReview.tsx
+++ b/react-app/src/components/PostReview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Post } from '../types'
+import type { Post } from '../types'
 import { getImageUrl, getTimeAgo } from '../services/helpers'
 
 const PostReview = ({ post }: { post: Post }) => {

--- a/react-app/src/components/PostReviewSale.tsx
+++ b/react-app/src/components/PostReviewSale.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Post } from '../types'
+import type { Post } from '../types'
 import { getImageUrl, getTimeAgo } from '../services/helpers'
 
 const displayRatingStars = (rating: number) => {

--- a/react-app/src/hooks/useAuth.ts
+++ b/react-app/src/hooks/useAuth.ts
@@ -3,9 +3,9 @@ import {
   useContext,
   useEffect,
   useState,
-  ReactNode,
   createElement,
 } from 'react'
+import type { ReactNode } from 'react'
 
 type AuthContextType = {
   token: string | null

--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import apiClient from '../services/apiClient'
 import styles from '../styles/flashsale.module.css'
-import { FlashSaleDeparture } from '../types'
+import type { FlashSaleDeparture } from '../types'
 
 type DetailResponse = {
   data: {

--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import apiClient from '../services/apiClient'
 import FlashSaleMenu from '../components/FlashSaleMenu'
 import styles from '../styles/flashsale.module.css'
-import { FlashSaleCollection } from '../types'
+import type { FlashSaleCollection } from '../types'
 
 type HomeResponse = {
   data: {

--- a/react-app/src/pages/Home.tsx
+++ b/react-app/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import apiClient from '../services/apiClient'
-import { Post, Statistics } from '../types'
+import type { Post, Statistics } from '../types'
 import PostReview from '../components/PostReview'
 import PostGeneral from '../components/PostGeneral'
 import PostReviewSale from '../components/PostReviewSale'

--- a/react-app/src/pages/Profile.tsx
+++ b/react-app/src/pages/Profile.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import profileService from '../services/profile'
 import { getImageUrl, getTimeAgo } from '../services/helpers'
-import { ProfileData } from '../types'
+import type { ProfileData } from '../types'
 
 const Profile = () => {
   const { token, logout } = useAuth()

--- a/react-app/src/pages/Voucher.tsx
+++ b/react-app/src/pages/Voucher.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import voucherService from '../services/voucher'
 import { getImageUrl } from '../services/helpers'
-import { Voucher } from '../types'
+import type { Voucher } from '../types'
 
 const VoucherPage = () => {
   const { id } = useParams()

--- a/react-app/src/services/profile.ts
+++ b/react-app/src/services/profile.ts
@@ -1,5 +1,5 @@
 import apiClient from './apiClient'
-import { ProfileData } from '../types'
+import type { ProfileData } from '../types'
 
 export const getProfile = (
   token: string,

--- a/react-app/src/services/voucher.ts
+++ b/react-app/src/services/voucher.ts
@@ -1,5 +1,5 @@
 import apiClient from './apiClient'
-import { Voucher } from '../types'
+import type { Voucher } from '../types'
 
 export const getVoucher = (token: string, id: string) =>
   apiClient


### PR DESCRIPTION
## Summary
- convert React and shared type imports to type-only declarations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b326b82f1c832992f06c2e7365605f