### PR TITLE
fix: handle optional departure dates in flash sale

### DIFF
--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -32,7 +32,7 @@ const FlashSaleDetail = () => {
       )
       setTourName(res.data.tour.output_json.data.name)
       setPrices(res.data.prices || [])
-      if (res.data.prices?.length) {
+      if (res.data.prices && res.data.prices[0]?.departure_date) {
         setSelected(res.data.prices[0].departure_date)
       }
     }
@@ -71,24 +71,17 @@ const FlashSaleDetail = () => {
       <h1>{tourName}</h1>
       <div className={styles.departures}>
         {prices
-          .filter(
-            (
-              p,
-            ): p is FlashSaleDeparture & {
-              departure_date: string
-              available_slots: number
-            } => (p.available_slots ?? 0) > 0 && !!p.departure_date,
-          )
+          .filter((p) => (p.available_slots ?? 0) > 0)
           .map((p) => (
             <button
-              key={p.departure_date}
+              key={p.departure_date ?? ''}
               className={
                 styles.departure +
                 (selected === p.departure_date ? ' ' + styles.selected : '')
               }
-              onClick={() => setSelected(p.departure_date)}
+              onClick={() => p.departure_date && setSelected(p.departure_date)}
             >
-              {new Date(p.departure_date).toLocaleDateString('vi-VN')}
+              {new Date(p.departure_date!).toLocaleDateString('vi-VN')}
             </button>
           ))}
       </div>


### PR DESCRIPTION
## Summary
- guard against missing departure_date when initializing selected flash sale date
- skip flash sale departures without available slots
- assert departure dates on click and display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3c11912408329a01fcd93b4ef8b21