### PR TITLE
feat: add hero section to flash sale

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -78,8 +78,12 @@ const Flashsale = () => {
 
   return (
     <div>
-      <h1>Flash Sale</h1>
-      {countdown && <p className={styles.countdown}>{countdown}</p>}
+      <section className={styles['hero-section']}>
+        <div className={styles['hero-container']}>
+          <h1>Flash Sale</h1>
+          {countdown && <p className={styles.countdown}>{countdown}</p>}
+        </div>
+      </section>
       <FlashSaleMenu items={menuItems} />
       {collections.map((col) => (
         <section

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -6,8 +6,24 @@
 .tour-card { transition: all 0.3s ease; }
 :global(input[type="number"]::-webkit-inner-spin-button),
 :global(input[type="number"]::-webkit-outer-spin-button) { -webkit-appearance: none; margin: 0; }
-.hero-section { background-image: linear-gradient(to right, rgba(0,0,0,0.7), rgba(0,0,0,0.3)), url('../images/flashsale.png');
-                    background-size: cover; background-position: center; }
+.hero-section {
+  background-image: linear-gradient(
+      rgba(0, 0, 0, 0.6),
+      rgba(0, 0, 0, 0.3)
+    ),
+    url('../images/flashsale.png');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  padding: 80px 20px;
+  text-align: center;
+  color: #fff;
+}
+
+.hero-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
 .collection-card { transition: transform 0.3s ease; }
 .collection-card:hover { transform: scale(1.02); }
 .date-pill { transition: all 0.2s ease; }


### PR DESCRIPTION
## Summary
- wrap Flashsale header in hero section with container
- add hero-section styles with padding, overlay, and centered text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b425a8cb708329a9c678e04db9027a