### PR TITLE
Enhance flash sale collection cards

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -25,6 +25,17 @@ const idMap: Record<string, string> = {
 const getIdCodeByName = (name: string) =>
   idMap[name] || name.toLowerCase().replace(/\s+/g, '_')
 
+const flagMap: Record<string, string> = {
+  'Tour Đài Loan': '🇹🇼',
+  'Tour Hàn Quốc': '🇰🇷',
+  'Tour Nhật Bản': '🇯🇵',
+  'Tour Châu Âu': '🇪🇺',
+  'Tour Châu Úc': '🇦🇺',
+  'Tour Trung Quốc': '🇨🇳',
+}
+
+const getCountryFlag = (name: string) => flagMap[name] || ''
+
 const formatDate = (iso?: string) => {
   if (!iso) return ''
   const d = new Date(iso)
@@ -90,7 +101,18 @@ const Flashsale = () => {
           id={getIdCodeByName(col.collection_name)}
           key={col.collection_name}
         >
-          <h2>{col.collection_name}</h2>
+          <div className={styles['collection-card']}>
+            <img src={col.collection_image} alt={col.collection_name} />
+            <div className={styles['collection-overlay']} />
+            <div className={styles['collection-title']}>
+              <h2>
+                <span className={styles['flag-icon']}>
+                  {getCountryFlag(col.collection_name)}
+                </span>
+                {col.collection_name}
+              </h2>
+            </div>
+          </div>
           <div className={styles['tours-grid']}>
             {col.tours.map((tour) => (
               <div key={tour.tour_id} className={styles['tour-card']}>

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -36,8 +36,43 @@
   max-width: 1200px;
   margin: 0 auto;
 }
-.collection-card { transition: transform 0.3s ease; }
-.collection-card:hover { transform: scale(1.02); }
+.collection-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  transition: transform 0.3s ease;
+}
+
+.collection-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.collection-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
+}
+
+.collection-title {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 1.5rem;
+  color: #fff;
+  display: flex;
+  align-items: center;
+}
+
+.flag-icon {
+  margin-right: 0.5rem;
+}
+
+.collection-card:hover {
+  transform: scale(1.02);
+}
 .date-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Add flag mapping and wrap flash sale collection hero image and title with overlay
- Style collection card with gradient overlay, absolute title, and hover scale effect

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4568d648c8329a4984f48783688d6