### PR TITLE
feat: add responsive flash sale menu

### DIFF
--- a/react-app/src/components/FlashSaleMenu.tsx
+++ b/react-app/src/components/FlashSaleMenu.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import { type FC, useState } from 'react'
 import styles from '../styles/flashsale-menu.module.css'
 
 interface MenuItem {
@@ -7,6 +7,8 @@ interface MenuItem {
 }
 
 const FlashSaleMenu: FC<{ items: MenuItem[] }> = ({ items }) => {
+  const [open, setOpen] = useState(false)
+
   const scrollTo = (id: string) => {
     const el = document.getElementById(id)
     if (el) {
@@ -14,13 +16,47 @@ const FlashSaleMenu: FC<{ items: MenuItem[] }> = ({ items }) => {
     }
   }
 
+  const handleNavigate = (id: string) => {
+    scrollTo(id)
+    setOpen(false)
+  }
+
   return (
     <div className={styles['flashsale-menu']}>
-      {items.map((item) => (
-        <button key={item.id} onClick={() => scrollTo(item.id)}>
-          {item.name}
+      <nav className={styles['desktop-menu']}>
+        {items.map((item) => (
+          <button key={item.id} onClick={() => handleNavigate(item.id)}>
+            {item.name}
+          </button>
+        ))}
+      </nav>
+
+      <button
+        className={styles['menu-toggle']}
+        onClick={() => setOpen(true)}
+        aria-label="Open menu"
+      >
+        ☰
+      </button>
+
+      <div
+        className={`${styles['mobile-slide-menu']} ${open ? styles.active : ''}`}
+      >
+        <button
+          className={styles['close-btn']}
+          onClick={() => setOpen(false)}
+          aria-label="Close menu"
+        >
+          ×
         </button>
-      ))}
+        <div className={styles['mobile-menu-items']}>
+          {items.map((item) => (
+            <button key={item.id} onClick={() => handleNavigate(item.id)}>
+              {item.name}
+            </button>
+          ))}
+        </div>
+      </div>
     </div>
   )
 }

--- a/react-app/src/styles/flashsale-menu.module.css
+++ b/react-app/src/styles/flashsale-menu.module.css
@@ -1,4 +1,14 @@
-
+/* Flash sale menu container */
+.flashsale-menu {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 1000;
+}
 
 /* Mobile toggle button */
 .menu-toggle {
@@ -46,15 +56,20 @@
     margin-top: 20px;
   }
   
-  .mobile-menu-items a {
+  .mobile-menu-items a,
+  .mobile-menu-items button {
     text-decoration: none;
     font-size: 14px;
     color: #333;
     padding: 8px 12px;
     border-radius: 6px;
+    background: none;
+    border: none;
+    text-align: left;
   }
-  
-  .mobile-menu-items a:hover {
+
+  .mobile-menu-items a:hover,
+  .mobile-menu-items button:hover {
     background: #f2f2f2;
   }
   
@@ -84,15 +99,20 @@
       font-weight: 500;
     }
   
-    .desktop-menu a {
+    .desktop-menu a,
+    .desktop-menu button {
       text-decoration: none;
       color: #333;
       padding: 6px 10px;
       border-radius: 4px;
       transition: background-color 0.2s ease;
+      background: none;
+      border: none;
+      cursor: pointer;
     }
-  
-    .desktop-menu a:hover {
+
+    .desktop-menu a:hover,
+    .desktop-menu button:hover {
       background-color: #f0f0f0;
     }
   }


### PR DESCRIPTION
## Summary
- style flash sale menu container for horizontal sticky layout
- support desktop and mobile navigation toggling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45a2094448329b209f9b2df17de58