### PR TITLE
Remove hover translation from date pill

### DIFF
--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -80,11 +80,10 @@
   border-radius: 9999px;
   padding: 0.25rem 0.75rem;
   font-size: 0.875rem;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease;
 }
 
 .date-pill:hover {
-  transform: translateY(-2px);
   background-color: #e5e7eb;
 }
 


### PR DESCRIPTION
## Summary
- align `.date-pill` styles with PHP by only transitioning background color
- drop hover translateY effect for consistent appearance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45c4ca0308329ab135be380ecc779