### PR TITLE
feat: make flash sale menu sticky bottom

### DIFF
--- a/react-app/index.html
+++ b/react-app/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/react-app/src/components/FlashSaleMenu.tsx
+++ b/react-app/src/components/FlashSaleMenu.tsx
@@ -36,7 +36,7 @@ const FlashSaleMenu: FC<{ items: MenuItem[] }> = ({ items }) => {
         onClick={() => setOpen(true)}
         aria-label="Open menu"
       >
-        ☰
+        <i className="ri-menu-line"></i>
       </button>
 
       <div
@@ -47,7 +47,7 @@ const FlashSaleMenu: FC<{ items: MenuItem[] }> = ({ items }) => {
           onClick={() => setOpen(false)}
           aria-label="Close menu"
         >
-          ×
+          <i className="ri-close-line"></i>
         </button>
         <div className={styles['mobile-menu-items']}>
           {items.map((item) => (

--- a/react-app/src/styles/flashsale-menu.module.css
+++ b/react-app/src/styles/flashsale-menu.module.css
@@ -1,12 +1,16 @@
 /* Flash sale menu container */
 .flashsale-menu {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: center;
   gap: 16px;
-  padding: 12px 16px;
+  padding: 16px;
   position: sticky;
-  top: 0;
+  bottom: 0;
   background: #fff;
+  box-shadow: 0 -4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 -2px 4px -2px rgba(0, 0, 0, 0.1);
   z-index: 1000;
 }
 
@@ -91,9 +95,10 @@
   @media (min-width: 769px) {
     .desktop-menu {
       display: flex !important;
-      gap: 24px;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 16px;
       align-items: center;
-      margin-left: 20px; /* Giúp menu gần logo hơn */
       font-family: 'Inter', sans-serif;
       font-size: 14px;
       font-weight: 500;


### PR DESCRIPTION
## Summary
- make flash sale menu stick to bottom with white background and shadow
- switch toggle icons to Remix icons and add CDN link
- adjust desktop menu spacing to match PHP version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b45cf7b500832989a06950c36bf03a