### PR TITLE
feat: enhance flash sale hero

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -91,8 +91,16 @@ const Flashsale = () => {
     <div>
       <section className={styles['hero-section']}>
         <div className={styles['hero-container']}>
-          <h1>Flash Sale</h1>
-          {countdown && <p className={styles.countdown}>{countdown}</p>}
+          <div className={styles['hero-content']}>
+            <h1>Flash Sale - Ngày Đẹp Đôi – Tour Giá Xinh 8.8</h1>
+            <p className={styles.tagline}>Bùng Nổ 8.8 – Bay Ngay Giá Sốc</p>
+            {countdown && (
+              <p className={styles.countdown}>
+                <i className="ri-time-line ri-lg mr-2" />
+                {countdown}
+              </p>
+            )}
+          </div>
         </div>
       </section>
       <FlashSaleMenu items={menuItems} />

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -1,6 +1,15 @@
 :global(:where([class^="ri-"])::before) { content: "\f3c2"; }
 :global(body) { font-family: 'Inter', sans-serif; }
-.countdown { animation: pulse 2s infinite; background-color: var(--primary); }
+.countdown {
+  animation: pulse 2s infinite;
+  background-color: var(--primary);
+  margin-top: 1rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  color: #fff;
+  border-radius: 9999px;
+}
 @keyframes pulse { 0% { transform: scale(1); } 50% { transform: scale(1.05); } 100% { transform: scale(1); } }
 .tour-card {
   background-color: #fff;
@@ -35,6 +44,22 @@
 .hero-container {
   max-width: 1200px;
   margin: 0 auto;
+}
+
+.hero-content {
+  width: 100%;
+  max-width: 36rem;
+  background-color: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(4px);
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  margin: 0 auto;
+}
+
+.tagline {
+  margin-top: 0.5rem;
+  color: rgba(255, 255, 255, 0.9);
 }
 .collection-card {
   position: relative;


### PR DESCRIPTION
## Summary
- enrich flash sale hero with new heading, tagline and countdown icon
- add translucent hero container and supporting styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b46118aae483299415e4bdfac75e29