### PR TITLE
Improve flash sale tour card hover and link styling

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -130,7 +130,12 @@ const Flashsale = () => {
                     </div>
                   ))}
                 </div>
-                <Link to={`/flashsale/${tour.tour_id}`}>Xem chi tiết</Link>
+                <Link
+                  to={`/flashsale/${tour.tour_id}`}
+                  className="bg-primary text-white rounded flex items-center justify-center"
+                >
+                  Xem chi tiết <i className="ri-arrow-right-line ri-lg ml-1" />
+                </Link>
               </div>
             ))}
           </div>

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -13,8 +13,7 @@
 }
 
 .tour-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
 }
 :global(input[type="number"]::-webkit-inner-spin-button),
 :global(input[type="number"]::-webkit-outer-spin-button) { -webkit-appearance: none; margin: 0; }


### PR DESCRIPTION
## Summary
- Remove hover translate and use Tailwind-like shadow on flash sale tour cards
- Style "Xem chi tiết" link as a primary button with arrow icon
- Confirm Remix Icon stylesheet for arrow rendering

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4611a50788329a57aa2fe69028df4