### PR TITLE
feat: add global inter font

### DIFF
--- a/react-app/index.html
+++ b/react-app/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400..700&display=swap"
+      rel="stylesheet"
+    />
     <title>Vite + React + TS</title>
     <link
       href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css"

--- a/react-app/src/styles/index.css
+++ b/react-app/src/styles/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Inter", system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
   --primary: #660066;


### PR DESCRIPTION
## Summary
- add Google Fonts preconnect links and import Inter font weights
- apply Inter as default font in global styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b472956b5c8329ad6cf6b629d2cac4