### PR TITLE
Remove collection-card hover transform

### DIFF
--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -94,9 +94,6 @@
   margin-right: 0.5rem;
 }
 
-.collection-card:hover {
-  transform: scale(1.02);
-}
 .date-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove `.collection-card:hover` scaling rule from Flash Sale home styles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b47bee565c8329accc46fb9a76aebb