### PR TITLE
style: refine flash sale card hover and link

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -147,7 +147,7 @@ const Flashsale = () => {
                 </div>
                 <Link
                   to={`/flashsale/${tour.tour_id}`}
-                  className="bg-primary text-white rounded flex items-center justify-center"
+                  className="mt-4 w-full bg-primary text-white py-2 px-4 rounded flex items-center justify-center hover:bg-purple-800 transition"
                 >
                   Xem chi tiết <i className="ri-arrow-right-line ri-lg ml-1" />
                 </Link>

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -1,4 +1,3 @@
-:global(:where([class^="ri-"])::before) { content: "\f3c2"; }
 :global(body) { font-family: 'Inter', sans-serif; }
 .countdown {
   animation: pulse 2s infinite;
@@ -18,11 +17,11 @@
   overflow: hidden;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   padding: 1rem;
-  transition: all 0.3s ease;
+  transition: box-shadow 0.3s ease;
 }
 
 .tour-card:hover {
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
 }
 :global(input[type="number"]::-webkit-inner-spin-button),
 :global(input[type="number"]::-webkit-outer-spin-button) { -webkit-appearance: none; margin: 0; }

--- a/react-app/src/styles/index.css
+++ b/react-app/src/styles/index.css
@@ -1,3 +1,5 @@
+@import url('https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css');
+
 :root {
   font-family: "Inter", system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- refine flash sale card hover effect using shadow-md
- style “Xem chi tiết” link as primary button with arrow icon
- import Remix Icon styles globally

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b47f06d118832994f509088009f539