### PR TITLE
refine flash sale menu styling

### DIFF
--- a/react-app/src/components/FlashSaleMenu.tsx
+++ b/react-app/src/components/FlashSaleMenu.tsx
@@ -33,22 +33,19 @@ const FlashSaleMenu: FC<{ items: MenuItem[] }> = ({ items }) => {
 
       <button
         className={styles['menu-toggle']}
-        onClick={() => setOpen(true)}
-        aria-label="Open menu"
+        onClick={() => setOpen(!open)}
+        aria-label={open ? 'Close menu' : 'Open menu'}
       >
-        <i className="ri-menu-line"></i>
+        {open ? (
+          <i className="ri-close-line"></i>
+        ) : (
+          <i className="ri-menu-line"></i>
+        )}
       </button>
 
       <div
         className={`${styles['mobile-slide-menu']} ${open ? styles.active : ''}`}
       >
-        <button
-          className={styles['close-btn']}
-          onClick={() => setOpen(false)}
-          aria-label="Close menu"
-        >
-          <i className="ri-close-line"></i>
-        </button>
         <div className={styles['mobile-menu-items']}>
           {items.map((item) => (
             <button key={item.id} onClick={() => handleNavigate(item.id)}>

--- a/react-app/src/styles/flashsale-menu.module.css
+++ b/react-app/src/styles/flashsale-menu.module.css
@@ -1,14 +1,16 @@
 /* Flash sale menu container */
 .flashsale-menu {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  width: 100%;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   gap: 16px;
   padding: 16px;
-  position: sticky;
-  bottom: 0;
-  background: #fff;
+  background-color: #fff;
   box-shadow: 0 -4px 6px -1px rgba(0, 0, 0, 0.1),
     0 -2px 4px -2px rgba(0, 0, 0, 0.1);
   z-index: 1000;
@@ -43,14 +45,6 @@
   
   .mobile-slide-menu.active {
     right: 0;
-  }
-  
-  .mobile-slide-menu .close-btn {
-    background: none;
-    border: none;
-    font-size: 22px;
-    align-self: flex-end;
-    cursor: pointer;
   }
   
   .mobile-menu-items {


### PR DESCRIPTION
## Summary
- make flash sale menu sticky at bottom with white background and shadow
- toggle mobile menu icon between hamburger and close

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4801b54cc8329b9c03fec4a8ee470