### PR TITLE
Center Flashsale destination sections

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -117,6 +117,7 @@ const Flashsale = () => {
         <section
           id={getIdCodeByName(col.collection_name)}
           key={col.collection_name}
+          className={styles['destination-section']}
         >
           <div className={styles['collection-card']}>
             <img src={col.collection_image} alt={col.collection_name} />

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -44,6 +44,12 @@
   margin: 0 auto;
 }
 
+.destination-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
 .hero-content {
   width: 100%;
   max-width: 36rem;
@@ -64,6 +70,7 @@
   overflow: hidden;
   border-radius: 0.5rem;
   transition: transform 0.3s ease;
+  width: 100%;
 }
 
 .collection-card img {


### PR DESCRIPTION
## Summary
- Wrap each flash sale destination block in a `destination-section` to constrain width and center content
- Add styling for `destination-section` and ensure banners scale with section width

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b519eacd808329a299be08496e8c18