### PR TITLE
style: add flash sale tour styles

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -135,7 +135,7 @@ const Flashsale = () => {
             {col.tours.map((tour) => (
               <div key={tour.tour_id} className={styles['tour-card']}>
                 <img src={tour.tour_image} alt={tour.tour_name} />
-                <h3>{tour.tour_name}</h3>
+                <h3 className={styles['tour-title']}>{tour.tour_name}</h3>
                 <div>
                   {tour.departures.slice(0, 4).map((dep) => (
                     <div
@@ -150,7 +150,7 @@ const Flashsale = () => {
                 </div>
                 <Link
                   to={`/flashsale/${tour.tour_id}`}
-                  className="mt-4 w-full bg-primary text-white py-2 px-4 rounded flex items-center justify-center hover:bg-purple-800 transition"
+                  className={styles['tour-button']}
                 >
                   Xem chi tiết <i className="ri-arrow-right-line ri-lg ml-1" />
                 </Link>

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -141,3 +141,22 @@
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+.tour-title {
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: #111827;
+}
+
+.tour-button {
+  margin-top: 1rem;
+  width: 100%;
+  background-color: var(--primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- apply dedicated styles to tour titles and action buttons in Flash Sale page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b51be95a488329b9d8a76d991ba659