### PR TITLE
feat: style Flashsale departure list

### DIFF
--- a/react-app/src/pages/Flashsale.tsx
+++ b/react-app/src/pages/Flashsale.tsx
@@ -136,7 +136,7 @@ const Flashsale = () => {
               <div key={tour.tour_id} className={styles['tour-card']}>
                 <img src={tour.tour_image} alt={tour.tour_name} />
                 <h3 className={styles['tour-title']}>{tour.tour_name}</h3>
-                <div>
+                <div className={styles['departure-list']}>
                   {tour.departures.slice(0, 4).map((dep) => (
                     <div
                       key={dep.date || dep.departure_date}

--- a/react-app/src/styles/flashsale-home.module.css
+++ b/react-app/src/styles/flashsale-home.module.css
@@ -100,6 +100,13 @@
   margin-right: 0.5rem;
 }
 
+.departure-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
 .date-pill {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- wrap Flashsale tour departure pills in a flex container
- add `.departure-list` styles for spacing and wrapping

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51c7ccbb483299f6cff400cfa2c5a