### PR TITLE
feat: improve flash sale detail header

### DIFF
--- a/react-app/index.html
+++ b/react-app/index.html
@@ -36,7 +36,7 @@
       content="https://yourdomain.com/images/flashsale-5-5.jpg"
     />
     <link
-      href="https://cdn.jsdelivr.net/npm/remixicon/fonts/remixicon.css"
+      href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css"
       rel="stylesheet"
     />
   </head>

--- a/react-app/src/styles/flashsale-detail.module.css
+++ b/react-app/src/styles/flashsale-detail.module.css
@@ -1,14 +1,40 @@
 :global(body) {
     font-family: 'Inter', sans-serif;
   }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
+  }
+
+  .back-button {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(4px);
+    color: #fff;
+    border-radius: 9999px;
+  }
+
+  .back-button:hover {
+    background: rgba(255, 255, 255, 0.3);
+  }
+
   .countdown {
     animation: pulse 2s infinite;
   }
+
   @keyframes pulse {
     0% { transform: scale(1); }
     50% { transform: scale(1.05); }
     100% { transform: scale(1); }
   }
+
   .gallery-img:hover {
     transform: scale(1.03);
     transition: transform 0.3s ease;


### PR DESCRIPTION
## Summary
- add hero header with back button and countdown on flash sale detail page
- style overlay and back button for flash sale detail
- load remix icon stylesheet for flash sale icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b55be60a74832989e0bef68c4b32f3