### PR TITLE
feat: add flash sale detail tabs

### DIFF
--- a/react-app/src/styles/flashsale-detail.module.css
+++ b/react-app/src/styles/flashsale-detail.module.css
@@ -1,158 +1,170 @@
 :global(body) {
-    font-family: 'Inter', sans-serif;
-  }
+  font-family: 'Inter', sans-serif;
+}
 
-  .overlay {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
-  }
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
+}
 
-  .back-button {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    display: inline-flex;
-    align-items: center;
-    padding: 0.5rem 0.75rem;
-    background: rgba(255, 255, 255, 0.2);
-    backdrop-filter: blur(4px);
-    color: #fff;
-    border-radius: 9999px;
-  }
+.back-button {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(4px);
+  color: #fff;
+  border-radius: 9999px;
+}
 
-  .back-button:hover {
-    background: rgba(255, 255, 255, 0.3);
-  }
+.back-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
 
-  .countdown {
-    animation: pulse 2s infinite;
-  }
+.countdown {
+  animation: pulse 2s infinite;
+}
 
-  @keyframes pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-    100% { transform: scale(1); }
+@keyframes pulse {
+  0% {
+    transform: scale(1);
   }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
 
-  .gallery-img:hover {
-    transform: scale(1.03);
-    transition: transform 0.3s ease;
-  }
-  .sticky-booking {
-    position: sticky;
-    top: 100px;
-  }
-  .timeline-dot::before {
-    content: '';
-    position: absolute;
-    left: -38px;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background-color: #660066;
-    border: 3px solid white;
-    box-shadow: 0 0 0 2px #660066;
-  }
-  .timeline-line::before {
-    content: '';
-    position: absolute;
-    left: -31px;
-    top: 16px;
-    bottom: -16px;
-    width: 2px;
-    background-color: #660066;
-  }
-  .tab-active {
-    color: #660066;
-    border-color: #660066;
-  }
-  .departures {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 4px;
-  }
-  .date-option {
-    background: #f3f4f6;
-    border-radius: 9999px;
-    padding: 2px 8px;
-    font-size: 12px;
-  }
-  .date-option:hover {
-    border-color: #660066;
-  }
-  .selected {
-    border-color: #660066;
-    background-color: rgba(102, 0, 102, 0.05);
-  }
-  .quantity-selector {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 8px;
-  }
-  .quantity-button {
-    padding: 2px 8px;
-  }
-  .quantity-input {
-    width: 48px;
-    text-align: center;
-  }
-  .booking-form {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-top: 16px;
-  }
-  .booking-input {
-    padding: 4px 8px;
-    border: 1px solid #d1d5db;
-    border-radius: 4px;
-  }
-  .booking-button {
-    padding: 8px;
-    background-color: #660066;
-    color: white;
-    border: none;
-    border-radius: 4px;
-  }
-  .review-progress-bar {
-    height: 6px;
-    background-color: #E0E0E0;
-    border-radius: 3px;
-    overflow: hidden;
-  }
-  .review-progress-bar-fill {
-    height: 100%;
-    background-color: #660066;
-  }
+.gallery-img {
+  transition: transform 0.3s ease;
+}
+.gallery-img:hover {
+  transform: scale(1.05);
+}
+.sticky-booking {
+  position: sticky;
+  top: 100px;
+}
+.timeline-dot::before {
+  content: '';
+  position: absolute;
+  left: -38px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: #660066;
+  border: 3px solid white;
+  box-shadow: 0 0 0 2px #660066;
+}
+.timeline-line::before {
+  content: '';
+  position: absolute;
+  left: -31px;
+  top: 16px;
+  bottom: -16px;
+  width: 2px;
+  background-color: #660066;
+}
+.tab-active {
+  color: #660066;
+  border-color: #660066;
+}
+.departures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+.date-option {
+  background: #f3f4f6;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+.date-option:hover {
+  border-color: #660066;
+}
+.selected {
+  border-color: #660066;
+  background-color: rgba(102, 0, 102, 0.05);
+}
+.quantity-selector {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+.quantity-button {
+  padding: 2px 8px;
+}
+.quantity-input {
+  width: 48px;
+  text-align: center;
+}
+.booking-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+.booking-input {
+  padding: 4px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+.booking-button {
+  padding: 8px;
+  background-color: #660066;
+  color: white;
+  border: none;
+  border-radius: 4px;
+}
+.review-progress-bar {
+  height: 6px;
+  background-color: #e0e0e0;
+  border-radius: 3px;
+  overflow: hidden;
+}
+.review-progress-bar-fill {
+  height: 100%;
+  background-color: #660066;
+}
 
-  .loading-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.6);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-    flex-direction: column;
-  }
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  flex-direction: column;
+}
 
-  .spinner {
-    width: 40px;
-    height: 40px;
-    margin-bottom: 10px;
-    border: 5px solid #f3f3f3;
-    border-top: 5px solid #660066;
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-  }
+.spinner {
+  width: 40px;
+  height: 40px;
+  margin-bottom: 10px;
+  border: 5px solid #f3f3f3;
+  border-top: 5px solid #660066;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
 
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
   }
+  100% {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- add sticky tab bar and scroll tracking for Flash Sale detail page
- display overview, itinerary timeline, attractions, gallery and services sections
- style tab navigation, timeline elements and gallery hover

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b56f8dac748329a9a91be601f9496e