### PR TITLE
Display flash sale departure details with pricing

### DIFF
--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -421,7 +421,7 @@ const FlashSaleDetail = () => {
             <div className="mt-4">
               <div className={`${styles.departures} mt-2`}>
                 {prices
-                  .filter((p) => (p.available_slots ?? 0) > 0)
+                  .filter((p) => p.available_slots > 0)
                   .map((p) => (
                     <button
                       key={p.departure_date ?? ''}
@@ -435,7 +435,31 @@ const FlashSaleDetail = () => {
                         p.departure_date && setSelected(p.departure_date)
                       }
                     >
-                      {new Date(p.departure_date!).toLocaleDateString('vi-VN')}
+                      <div>
+                        <div className="font-medium">
+                          {new Date(p.departure_date!).toLocaleDateString(
+                            'vi-VN',
+                          )}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          Còn {p.available_slots} chỗ
+                        </div>
+                        {p.short_title && (
+                          <div className="text-xs text-red-600">
+                            ({p.short_title})
+                          </div>
+                        )}
+                      </div>
+                      <div className="text-right">
+                        {p.is_flash_sale && (
+                          <span className="text-gray-500 line-through text-sm">
+                            {formatCurrency(Math.ceil(p.price * 1.15))}
+                          </span>
+                        )}
+                        <div className="text-primary font-bold">
+                          {formatCurrency(p.price)}
+                        </div>
+                      </div>
                     </button>
                   ))}
               </div>

--- a/react-app/src/styles/flashsale-detail.module.css
+++ b/react-app/src/styles/flashsale-detail.module.css
@@ -78,19 +78,24 @@
 }
 .departures {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 8px;
   margin-top: 4px;
 }
 .date-option {
-  background: #f3f4f6;
-  border: 1px solid #d1d5db;
-  border-radius: 9999px;
-  padding: 2px 8px;
-  font-size: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  cursor: pointer;
 }
 .date-option:hover {
   border-color: #660066;
+  background-color: #f9fafb;
 }
 .selected {
   border-color: #660066;

--- a/react-app/src/types.ts
+++ b/react-app/src/types.ts
@@ -50,7 +50,9 @@ export interface FlashSaleDeparture {
   date?: string
   departure_date?: string
   price: number
-  available_slots?: number
+  available_slots: number
+  short_title?: string
+  is_flash_sale: boolean
 }
 
 export interface FlashSaleTour {


### PR DESCRIPTION
## Summary
- show departure date, availability, short title and pricing (with strike-through for flash sales)
- add available_slots, short_title and is_flash_sale to FlashSaleDeparture type
- style date options with flex layout, borders, hover and selected states

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5775b79a483298b2002738204b069