### PR TITLE
Add custom tour request overlay to Flash Sale detail

### DIFF
--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -196,12 +196,19 @@ const FlashSaleDetail = () => {
     if (!id) return
     setDesigning(true)
     try {
-      await apiClient.post('/api/v1/custom-tours/from-app-tour', {
+      const res = await apiClient.post<{
+        status: string
+        data?: { custom_tour_id?: string }
+      }>('/api/v1/custom-tours/from-app-tour', {
         tour_id: id,
         departure_date: selected,
         expected_guests: quantity,
       })
-      alert('Yêu cầu đã được gửi')
+      if (res.status === 'success' && res.data?.custom_tour_id) {
+        window.location.href = `https://customtour.tugo.com.vn/?id=${res.data.custom_tour_id}`
+      } else {
+        alert('Đã có lỗi xảy ra')
+      }
     } catch {
       alert('Không thể gửi yêu cầu')
     } finally {
@@ -410,6 +417,7 @@ const FlashSaleDetail = () => {
               </div>
               <div className="mt-2">
                 <button
+                  id="customTourBtn"
                   className="bg-primary text-white px-5 py-2 rounded font-bold"
                   onClick={designTour}
                   disabled={designing}
@@ -548,9 +556,9 @@ const FlashSaleDetail = () => {
       </div>
 
       {designing && (
-        <div className={styles['loading-overlay']}>
-          <div className="text-center">
-            <div className={styles.spinner} />
+        <div id="loadingOverlay">
+          <div id="loadingContent">
+            <div id="loadingIcon" />
             <div className="mt-2 text-white font-bold">
               Hệ thống đang xử lý...
             </div>

--- a/react-app/src/styles/flashsale-detail.module.css
+++ b/react-app/src/styles/flashsale-detail.module.css
@@ -179,7 +179,7 @@
   background-color: #660066;
 }
 
-.loading-overlay {
+:global(#loadingOverlay) {
   position: fixed;
   top: 0;
   left: 0;
@@ -190,15 +190,20 @@
   justify-content: center;
   align-items: center;
   z-index: 9999;
-  flex-direction: column;
 }
 
-.spinner {
+:global(#loadingContent) {
+  text-align: center;
+  color: white;
+  font-family: Arial, sans-serif;
+}
+
+:global(#loadingIcon) {
   width: 40px;
   height: 40px;
   margin-bottom: 10px;
   border: 5px solid #f3f3f3;
-  border-top: 5px solid #660066;
+  border-top: 5px solid #800080;
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }


### PR DESCRIPTION
## Summary
- add "Thiết kế tour riêng" button to FlashSaleDetail info card
- post to custom tour API with loading overlay and redirect on success
- style loading overlay and spinner animation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5810ae86c8329a0770e40bd5a9cab