### PR TITLE
Adjust flash sale detail hero banner height

### DIFF
--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -240,7 +240,7 @@ const FlashSaleDetail = () => {
           content={typeof window !== 'undefined' ? window.location.href : ''}
         />
       </Helmet>
-      <div className="relative h-96">
+      <div className={`relative ${styles['hero-banner']}`}>
         {tourImage && (
           <img
             src={tourImage}

--- a/react-app/src/styles/flashsale-detail.module.css
+++ b/react-app/src/styles/flashsale-detail.module.css
@@ -8,6 +8,11 @@
   background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
 }
 
+.hero-banner {
+  height: 380px;
+  overflow: hidden;
+}
+
 .back-button {
   position: absolute;
   top: 1rem;


### PR DESCRIPTION
## Summary
- limit flash sale hero banner height to 380px and allow page content to scroll beneath
- add hero-banner class to style to avoid fixed positioning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5b60e97ec832995dd3c360f426c28