### PR TITLE
feat: improve flash sale gallery responsiveness

### DIFF
--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -375,7 +375,7 @@ const FlashSaleDetail = () => {
             <h2 className="text-xl font-bold text-gray-900 mb-4">
               Thư viện hình ảnh
             </h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
               {tourGallery.map((photo, idx) => (
                 <div key={idx} className="overflow-hidden rounded-lg shadow-sm">
                   <img


### PR DESCRIPTION
## Summary
- allow gallery to show 3 columns on medium screens and 4 on large screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba77a2788329ad506564c2b196cc