### PR TITLE
fix: position flash sale hero overlay

### DIFF
--- a/react-app/src/pages/FlashSaleDetail.tsx
+++ b/react-app/src/pages/FlashSaleDetail.tsx
@@ -242,13 +242,15 @@ const FlashSaleDetail = () => {
       </Helmet>
       <div className={`relative ${styles['hero-banner']}`}>
         {tourImage && (
-          <img
-            src={tourImage}
-            alt={tourName}
-            className="w-full h-full object-cover object-top"
-          />
+          <>
+            <img
+              src={tourImage}
+              alt={tourName}
+              className="w-full h-full object-cover object-top"
+            />
+            <div className={styles.overlay} />
+          </>
         )}
-        <div className={styles.overlay} />
         <a href="/flashsale" className={styles['back-button']}>
           <i className="ri-arrow-left-line ri-lg mr-1" />
           <span>Quay lại</span>

--- a/react-app/src/styles/flashsale-detail.module.css
+++ b/react-app/src/styles/flashsale-detail.module.css
@@ -6,6 +6,7 @@
   position: absolute;
   inset: 0;
   background: linear-gradient(to top, rgba(0, 0, 0, 0.6), transparent);
+  pointer-events: none;
 }
 
 .section {


### PR DESCRIPTION
## Summary
- nest hero image overlay before navigation content in FlashSaleDetail
- ensure overlay ignores pointer events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf0973d083298e11eb31cdbd4e55